### PR TITLE
wrong number for alt circuits in data.json

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,1 @@
-theme: jekyll-theme-cayman
+theme: jekyll-theme-slate

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-slate

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/data/data.json
+++ b/data/data.json
@@ -1403,7 +1403,7 @@
             "time": 24,
             "ingredients": [
                 ["copper-sheet", 11],
-                ["silica", 1]
+                ["silica", 11]
             ],
             "product": ["circuit-board", 5],
             "byproduct": ["copper-ingot", 999]


### PR DESCRIPTION
sorry for messy logs, i did it on the browser and dont have squash, you can just fix your version and reject this pull. Also, got a site or know a site that using this instead of me hosting a io page?